### PR TITLE
Fix ruby engine detection such that it detects Ruby 1.8.7

### DIFF
--- a/lib/thread_safe.rb
+++ b/lib/thread_safe.rb
@@ -27,7 +27,7 @@ module ThreadSafe
     class Hash < ::Hash
       include JRuby::Synchronized
     end
-  elsif defined?(RUBY_ENGINE) && RUBY_ENGINE == 'ruby'
+  elsif !defined?(RUBY_ENGINE) || RUBY_ENGINE == 'ruby'
     # Because MRI never runs code in parallel, the existing
     # non-thread-safe structures should usually work fine.
     Array = ::Array

--- a/lib/thread_safe/cache.rb
+++ b/lib/thread_safe/cache.rb
@@ -7,8 +7,8 @@ module ThreadSafe
   autoload :AtomicReferenceCacheBackend, 'thread_safe/atomic_reference_cache_backend'
   autoload :SynchronizedCacheBackend,    'thread_safe/synchronized_cache_backend'
 
-  ConcurrentCacheBackend =
-    case defined?(RUBY_ENGINE) && RUBY_ENGINE
+  ConcurrentCacheBackend = if defined?(RUBY_ENGINE)
+    case RUBY_ENGINE
     when 'jruby'; JRubyCacheBackend
     when 'ruby';  MriCacheBackend
     when 'rbx';   AtomicReferenceCacheBackend
@@ -16,6 +16,9 @@ module ThreadSafe
       warn 'ThreadSafe: unsupported Ruby engine, using a fully synchronized ThreadSafe::Cache implementation' if $VERBOSE
       SynchronizedCacheBackend
     end
+  else
+    MriCacheBackend
+  end
 
   class Cache < ConcurrentCacheBackend
     KEY_ERROR = defined?(KeyError) ? KeyError : IndexError # there is no KeyError in 1.8 mode


### PR DESCRIPTION
Based on bundler's ruby engine detection:

https://github.com/carlhuda/bundler/blob/438ef20987951883cb5837d245eac9c517848b2d/lib/bundler/ruby_version.rb

Fixes https://github.com/headius/thread_safe/issues/5
