### PR TITLE
Added method aliases for simple Cache operations

### DIFF
--- a/lib/thread_safe/cache.rb
+++ b/lib/thread_safe/cache.rb
@@ -41,6 +41,9 @@ module ThreadSafe
       end
     end
 
+    alias_method :get, :[]
+    alias_method :put, :[]=
+
     def fetch(key, default_value = NULL)
       if NULL != (value = get_or_default(key, NULL))
         value

--- a/test/test_cache.rb
+++ b/test/test_cache.rb
@@ -29,8 +29,10 @@ class TestCache < Test::Unit::TestCase
   def test_retrieval
     assert_size_change 1 do
       assert_equal nil, @cache[:a]
+      assert_equal nil, @cache.get(:a)
       @cache[:a] = 1
       assert_equal 1,   @cache[:a]
+      assert_equal 1,   @cache.get(:a)
     end
   end
 


### PR DESCRIPTION
For those of us that prefer using methods over array notation when doing simple retrieval/storage operations.
