### PR TITLE
Fix fallback if atomic can't be required.

### DIFF
--- a/lib/thread_safe/util/atomic_reference.rb
+++ b/lib/thread_safe/util/atomic_reference.rb
@@ -8,7 +8,7 @@ module ThreadSafe
         begin
           require 'atomic'
           defined?(Atomic::InternalReference) ? Atomic::InternalReference : Atomic
-        rescue NameError
+        rescue LoadError,NameError
           require 'thread' # get Mutex on 1.8
           class FullLockingAtomicReference
             def initialize(value = nil)


### PR DESCRIPTION
https://github.com/headius/thread_safe/commit/33114e71ad538745800f49f445effff2e60146ac removed the atomic dependency, but it still is a development dependency of the gem so in development `require 'atomic'` never fails, which means we never have to rescue `LoadError`. In a real Rails App where we updated thread_safe just now this failed obviously.
