### PR TITLE
Modify README.md to explain code move into concurrent-ruby.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-This library has been moved to https://github.com/ruby-concurrency/thread_safe.
-
-It will likely be merged with the concurrent-ruby gem in the same organization.
+This code base is now part of the concurrent-ruby gem
+at https://github.com/ruby-concurrency/concurrent-ruby.
+The code in this repository is no longer maintained.


### PR DESCRIPTION
Modify README.md to explain that this code has been moved into the concurrent-ruby gem.
